### PR TITLE
Potential fix for code scanning alert no. 10: Partial server-side request forgery

### DIFF
--- a/pokedex/views.py
+++ b/pokedex/views.py
@@ -51,7 +51,13 @@ def getAllPokemon(request):
     )
 
 def getPokemonById(request, id):
-    url = f"{API_URL}{id}"
+    try:
+        pokemon_id = int(id)
+        if pokemon_id <= 0:
+            return HttpResponse("Invalid Pokémon ID", status=400)
+    except (TypeError, ValueError):
+        return HttpResponse("Invalid Pokémon ID", status=400)
+    url = f"{API_URL}{pokemon_id}"
     response = requests.get(url)
     if response.status_code == 200:
         data = response.json()


### PR DESCRIPTION
Potential fix for [https://github.com/Al-vallon/ci_pokedex/security/code-scanning/10](https://github.com/Al-vallon/ci_pokedex/security/code-scanning/10)

To fix the issue, we should avoid using the raw user-provided `id` directly in the request URL and instead validate and normalize it to an allowed format before calling `requests.get`. In this case, `id` is conceptually a numeric Pokémon ID, so the best fix is to enforce that it is a positive integer and reject any invalid values with a clear HTTP error. This removes the taint from the URL path component and ensures the request is always to `https://pokeapi.co/api/v2/pokemon/<positive-int>`.

Concretely, within `getPokemonById` in `pokedex/views.py`, we can:

1. Attempt to convert `id` to an integer using `int(id)`.
2. Check that it is positive (greater than zero).
3. If conversion fails or the value is invalid, return an HTTP 400 (bad request) or 404.
4. Use the validated integer form when building the URL (e.g., `f"{API_URL}{pokemon_id}"`).

No new imports are needed; we only use built-in `int` and existing `HttpResponse`. This change preserves existing functionality for valid IDs while preventing malformed or malicious values from reaching the `requests.get` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
