### PR TITLE
Potential fix for code scanning alert no. 9: Partial server-side request forgery

### DIFF
--- a/pokedex/views.py
+++ b/pokedex/views.py
@@ -1,7 +1,34 @@
 from django.shortcuts import render
 from django.http import HttpResponse
 import requests
+from urllib.parse import urlparse
 API_URL = "https://pokeapi.co/api/v2/pokemon/"
+
+
+def _is_allowed_pokemon_detail_url(url):
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False
+
+    if parsed.scheme != "https":
+        return False
+    if parsed.netloc != "pokeapi.co":
+        return False
+    if parsed.query or parsed.fragment:
+        return False
+
+    path = parsed.path.rstrip("/")
+    parts = path.split("/")
+    # expected: /api/v2/pokemon/<id>
+    if len(parts) != 5:
+        return False
+    if parts[1] != "api" or parts[2] != "v2" or parts[3] != "pokemon":
+        return False
+    if not parts[4].isdigit():
+        return False
+
+    return True
 
 def getAllPokemon(request):
     offset = request.GET.get("offset", 0)
@@ -27,6 +54,8 @@ def getAllPokemon(request):
     all_pokemons = []
     for pokemon in pokemons:
         pokemon_url = pokemon['url']
+        if not _is_allowed_pokemon_detail_url(pokemon_url):
+            continue
         try:
             response_pokemon = requests.get(pokemon_url)
             response_pokemon.raise_for_status()
@@ -87,6 +116,8 @@ def searchPokemon(request):
     all_pokemons = []
     for pokemon in matching_pokemons:
         pokemon_url = pokemon['url']
+        if not _is_allowed_pokemon_detail_url(pokemon_url):
+            continue
         try:
             response_pokemon = requests.get(pokemon_url)
             response_pokemon.raise_for_status()


### PR DESCRIPTION
Potential fix for [https://github.com/Al-vallon/ci_pokedex/security/code-scanning/9](https://github.com/Al-vallon/ci_pokedex/security/code-scanning/9)

Best fix: **validate and constrain fetched detail URLs to a strict allowlist pattern** before calling `requests.get`. Keep behavior unchanged for valid PokeAPI URLs.

Concretely in `pokedex/views.py`:
- Add `from urllib.parse import urlparse`.
- Add a helper function (for reuse in both loops) that only accepts:
  - scheme `https`
  - host `pokeapi.co`
  - path matching `/api/v2/pokemon/<numeric-id>/` (optionally trailing slash)
  - no query/fragment
- In `getAllPokemon` and `searchPokemon`, before `requests.get(pokemon_url)`, reject/skip entries failing validation.

This preserves current functionality (still fetches Pokémon details) while preventing attacker-influenced URLs from being requested.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds URL allowlisting before issuing external `requests.get` calls, which reduces SSRF risk but can change behavior by skipping any unexpected/malformed Pokémon URLs returned by the upstream API.
> 
> **Overview**
> Hardens Pokémon list and search flows against partial SSRF by introducing `_is_allowed_pokemon_detail_url()` to strictly allowlist `https://pokeapi.co/api/v2/pokemon/<numeric-id>` URLs (no query/fragment).
> 
> Both `getAllPokemon` and `searchPokemon` now validate each `pokemon['url']` and *skip* entries that fail validation before fetching details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f7d9475e758c7cfc4597d8083cbbd8f7640e6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->