### PR TITLE
Potential fix for code scanning alert no. 9: Partial server-side request forgery

### DIFF
--- a/pokedex/views.py
+++ b/pokedex/views.py
@@ -57,7 +57,9 @@ def getAllPokemon(request):
         if not _is_allowed_pokemon_detail_url(pokemon_url):
             continue
         try:
-            response_pokemon = requests.get(pokemon_url)
+            pokemon_id = pokemon_url.rstrip("/").split("/")[-1]
+            detail_url = f"{API_URL}{pokemon_id}"
+            response_pokemon = requests.get(detail_url)
             response_pokemon.raise_for_status()
             data_pokemon = response_pokemon.json()
             name = data_pokemon['name']


### PR DESCRIPTION
Potential fix for [https://github.com/Al-vallon/ci_pokedex/security/code-scanning/9](https://github.com/Al-vallon/ci_pokedex/security/code-scanning/9)

Use server-controlled URL construction for detail fetches instead of calling `requests.get` on `pokemon['url']`.

Best fix in this file:
- In `getAllPokemon` loop (around lines 55–61), stop using `pokemon_url` directly for outbound request.
- Keep the existing `_is_allowed_pokemon_detail_url` check (defense-in-depth).
- Parse the numeric Pokémon ID from the validated URL path and build a canonical URL via `API_URL`:
  - `pokemon_id = pokemon_url.rstrip("/").split("/")[-1]`
  - `detail_url = f"{API_URL}{pokemon_id}"`
  - `requests.get(detail_url)`

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to how Pokémon detail URLs are constructed; main concern is potential mismatches if the upstream URL format changes or IDs are parsed incorrectly.
> 
> **Overview**
> Updates `getAllPokemon` to **stop calling `requests.get` on the upstream-provided `pokemon['url']`** and instead parse the Pokémon ID from the validated URL and fetch details via a server-constructed canonical `API_URL`.
> 
> Keeps the existing `_is_allowed_pokemon_detail_url` allowlist check as defense-in-depth while ensuring outbound requests are constrained to the expected PokeAPI host and path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76168b4293ead9434e21f5622d8f3d3d213b992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->