### PR TITLE
Potential fix for code scanning alert no. 13: Partial server-side request forgery

### DIFF
--- a/pokedex/views.py
+++ b/pokedex/views.py
@@ -31,10 +31,22 @@ def _is_allowed_pokemon_detail_url(url):
     return True
 
 def getAllPokemon(request):
-    offset = request.GET.get("offset", 0)
-    limit = request.GET.get("limit", 20)
     try:
-        response = requests.get(f"{API_URL}?offset={offset}&limit={limit}")
+        offset = int(request.GET.get("offset", 0))
+    except (TypeError, ValueError):
+        offset = 0
+    if offset < 0:
+        offset = 0
+
+    try:
+        limit = int(request.GET.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
+    if limit < 1:
+        limit = 20
+
+    try:
+        response = requests.get(API_URL, params={"offset": offset, "limit": limit}, timeout=10)
         response.raise_for_status()
         data = response.json()
     except requests.exceptions.RequestException:
@@ -57,9 +69,9 @@ def getAllPokemon(request):
         if not _is_allowed_pokemon_detail_url(pokemon_url):
             continue
         try:
-            pokemon_id = pokemon_url.rstrip("/").split("/")[-1]
+            pokemon_id = int(pokemon_url.rstrip("/").split("/")[-1])
             detail_url = f"{API_URL}{pokemon_id}"
-            response_pokemon = requests.get(detail_url)
+            response_pokemon = requests.get(detail_url, timeout=10)
             response_pokemon.raise_for_status()
             data_pokemon = response_pokemon.json()
             name = data_pokemon['name']
@@ -68,7 +80,7 @@ def getAllPokemon(request):
                 'name': name,
                 'image_url': image_url,
             })
-        except requests.exceptions.RequestException:
+        except (ValueError, requests.exceptions.RequestException):
             continue
     return render(
         request,


### PR DESCRIPTION
Potential fix for [https://github.com/Al-vallon/ci_pokedex/security/code-scanning/13](https://github.com/Al-vallon/ci_pokedex/security/code-scanning/13)

To fix this without changing functionality, stop building `detail_url` from tainted URL fragments and instead enforce strict integer validation and use `requests` query params for list retrieval.

Best approach in `pokedex/views.py`:
1. In `getAllPokemon`, parse `offset` and `limit` to integers with safe defaults and bounds.
2. Call list endpoint with `requests.get(API_URL, params={...})` instead of string interpolation.
3. In the loop, after `_is_allowed_pokemon_detail_url`, parse `pokemon_id` as `int` and reconstruct `detail_url` from this validated integer only.
4. Optionally add timeouts to outbound requests for safer network behavior.

This keeps behavior the same (fetch list then fetch per-Pokémon detail) while removing direct dependence on tainted URL text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds stricter validation and timeout handling around outbound HTTP calls; low functional change but impacts request/response behavior and could affect pagination edge cases or error handling.
> 
> **Overview**
> **Hardens PokeAPI fetching in `getAllPokemon`.** Pagination inputs (`offset`, `limit`) are now parsed as integers with safe defaults and basic bounds, and the list call uses `requests.get(..., params=...)` instead of URL string interpolation.
> 
> **Reduces SSRF/robustness risk for detail fetches.** Pokémon IDs are converted to `int` before constructing `detail_url`, invalid IDs are skipped, and both list/detail requests now include a `timeout=10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 324e274b59628762cd5d50a93d1d40598251d067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->